### PR TITLE
remove jiffy encoding

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluent/fluentd:latest
+FROM fluent/fluentd:v1.2.2
 MAINTAINER tkyshm
 
 ADD fluent.conf /fluentd/etc/fluent.conf

--- a/elvis.config
+++ b/elvis.config
@@ -22,7 +22,7 @@
             {elvis_project, protocol_for_deps_rebar,
              #{regex => "(https://|git://|git@).*"}},
             {elvis_project, no_deps_master_rebar,
-             #{ignore => [lager, jiffy]}}
+             #{ignore => [lager]}}
         ]
        },
       #{dirs => ["."],

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,5 @@
 {erl_opts, [debug_info]}.
 {deps, [
-         {msgpack, "0.7.0"},
-         {jiffy, "0.14.11"}
+         {msgpack, "0.7.0"}
        ]}.
 {ct_opts, [{keep_logs, 1}]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,8 +1,6 @@
 {"1.1.0",
-[{<<"jiffy">>,{pkg,<<"jiffy">>,<<"0.14.11">>},0},
- {<<"msgpack">>,{pkg,<<"msgpack">>,<<"0.7.0">>},0}]}.
+[{<<"msgpack">>,{pkg,<<"msgpack">>,<<"0.7.0">>},0}]}.
 [
 {pkg_hash,[
- {<<"jiffy">>, <<"919A87D491C5A6B5E3BBC27FAFEDC3A0761CA0B4C405394F121F582FD4E3F0E5">>},
  {<<"msgpack">>, <<"128AE0A2227C7E7A2847C0F0F73551C268464F8C1EE96BFFB920BC0A5712B295">>}]}
 ].

--- a/src/efluentc_client.erl
+++ b/src/efluentc_client.erl
@@ -245,20 +245,12 @@ code_change(_OldVsn, StateName, State, _Extra) ->
     {ok, StateName, State}.
 
 % @private
-encode_msg(Tag, Data) when is_binary(Tag) and is_binary(Data) ->
+encode_msg(Tag, Data) when is_binary(Tag) ->
     {Msec, Sec, _} = os:timestamp(),
     Package = [Tag, Msec*1000000+Sec, Data],
     msgpack:pack(Package, []);
-encode_msg(Tag, Data) when is_binary(Tag) and is_list(Data) ->
-    encode_msg(Tag, list_to_binary(Data));
-encode_msg(Tag, Data) when is_binary(Tag) and is_map(Data) ->
-    encode_msg(Tag, jiffy:encode(Data));
-encode_msg(Tag, Data) when is_atom(Tag) and is_binary(Data) ->
-    encode_msg(atom_to_binary(Tag, latin1), Data);
-encode_msg(Tag, Data) when is_atom(Tag) and is_list(Data) ->
-    encode_msg(atom_to_binary(Tag, latin1), list_to_binary(Data));
-encode_msg(Tag, Data) when is_atom(Tag) and is_map(Data) ->
-    encode_msg(atom_to_binary(Tag, latin1), jiffy:encode(Data)).
+encode_msg(Tag, Data) when is_atom(Tag) ->
+    encode_msg(atom_to_binary(Tag, latin1), Data).
 
 % @private
 try_connect(State = #state{buffer = Buffs}) when byte_size(Buffs) > 0 ->

--- a/test/efluentc_SUITE.erl
+++ b/test/efluentc_SUITE.erl
@@ -119,12 +119,12 @@ t_post(Config) ->
     PostTestFn =
     fun(Tag, Msg) ->
             efluentc:post(Tag, Msg),
-            {BinTag, BinMsg} = convert_tag_msg(Tag, Msg),
+            {WantTag, WantMsg} = convert_tag_msg(Tag, Msg),
             receive
                 {_, RecvMsg} ->
-                    {ok, [GotTag, _, GotMsg]} = msgpack:unpack(RecvMsg),
-                    GotTag = BinTag,
-                    GotMsg = BinMsg
+                    {ok, [GotTag, _, GotMsg]} = msgpack:unpack(RecvMsg, [{unpack_str, as_binary}]),
+                    GotTag = WantTag,
+                    GotMsg = WantMsg
             after 3000 ->
                 ct:fail(timeout_receive)
             end
@@ -181,8 +181,7 @@ convert_tag_msg(Tag, Msg) when is_atom(Tag) and is_list(Msg) ->
     {BinTag, BinMsg};
 convert_tag_msg(Tag, Msg) when is_atom(Tag) and is_map(Msg) ->
     BinTag = atom_to_binary(Tag, latin1),
-    BinMsg = jiffy:encode(Msg),
-    {BinTag, BinMsg};
+    {BinTag, Msg};
 convert_tag_msg(Tag, Msg) when is_atom(Tag) ->
     BinTag = atom_to_binary(Tag, latin1),
     {BinTag, Msg};
@@ -190,7 +189,6 @@ convert_tag_msg(Tag, Msg) when is_list(Msg) ->
     BinMsg = list_to_binary(Msg),
     {Tag, BinMsg};
 convert_tag_msg(Tag, Msg) when is_map(Msg) ->
-    BinMsg = jiffy:encode(Msg),
-    {Tag, BinMsg};
+    {Tag, Msg};
 convert_tag_msg(Tag, Msg) ->
     {Tag, Msg}.


### PR DESCRIPTION
It is not necessary to encode into json because its process is in msgpack.
And, I found messages sent to fluentd that are escaped when to post as encoded json binary. 
So,  that should not be encoded to json before to pack as msgpack.